### PR TITLE
Update manifest to fix build error

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -4,6 +4,7 @@
 #
 version: 3.0.1
 apiversion: 2
+architectures: armeabi armeabi-v7a x86
 description: In-App Billing Module
 author: Alexander Conway (Logical Labs) and Jon Alter
 license: Apache License, Version 2.0


### PR DESCRIPTION
Build fails when there is discrepancy between the architectures specified in manifest and compiled binary.
