### PR TITLE
Add External Validation helper

### DIFF
--- a/android/build.properties.example
+++ b/android/build.properties.example
@@ -4,5 +4,5 @@ titanium.version=3.2.2.GA
 android.sdk=/usr/android-sdk
 
 titanium.platform=${titanium.sdk}/mobilesdk/${titanium.os}/${titanium.version}/android
-android.platform=${android.sdk}/platforms/android-8
+android.platform=${android.sdk}/platforms/android-23
 google.apis=${android.sdk}/add-ons/addon_google_apis_google_inc_8

--- a/android/documentation/changelog.md
+++ b/android/documentation/changelog.md
@@ -1,5 +1,7 @@
 # Change Log
 <pre>
+v3.0.2  Compiled module with latest SDK (platform 23) and NDK (r10e) [MOD-2154]
+
 v3.0.1  Open sourcing module [MOD-1730]
 
 v3.0.0  Updating to Google In-App Billing api v3 [MOD-1355]

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.2
+version: 3.0.3
 apiversion: 2
 architectures: armeabi armeabi-v7a x86
 description: In-App Billing Module
@@ -16,4 +16,4 @@ name: inappbilling
 moduleid: ti.inappbilling
 guid: 3bdb4cb3-765b-41cc-8268-d8deb35ece07
 platform: android
-minsdk: 4.0.0.GA
+minsdk: 5.3.1.GA

--- a/android/manifest
+++ b/android/manifest
@@ -2,8 +2,9 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.1
+version: 3.0.2
 apiversion: 2
+architectures: armeabi armeabi-v7a x86
 description: In-App Billing Module
 author: Alexander Conway (Logical Labs) and Jon Alter
 license: Apache License, Version 2.0
@@ -15,4 +16,4 @@ name: inappbilling
 moduleid: ti.inappbilling
 guid: 3bdb4cb3-765b-41cc-8268-d8deb35ece07
 platform: android
-minsdk: 3.2.2.GA
+minsdk: 4.0.0.GA

--- a/android/src/ti/inappbilling/PurchaseProxy.java
+++ b/android/src/ti/inappbilling/PurchaseProxy.java
@@ -6,6 +6,7 @@
 
 package ti.inappbilling;
 
+import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollProxy;
 import org.appcelerator.kroll.annotations.Kroll;
 
@@ -39,6 +40,15 @@ public class PurchaseProxy extends KrollProxy {
     public String getToken() { return purchase.getToken(); }
     @Kroll.method @Kroll.getProperty
     public String getSignature() { return purchase.getSignature(); }
+    @Kroll.method @Kroll.getProperty
+    public KrollDict getReceipt() {
+        KrollDict receipt = new KrollDict();
+        receipt.put("data", purchase.getOriginalJson());
+        receipt.put("signature", purchase.getSignature());
+        return receipt;
+    }
+    
+
 
     public Purchase getPurchase() { return purchase; }
 }


### PR DESCRIPTION
Validating your receipt externally is a PITA currently, this adds a helper function that returns exactly what you need. 

Tested with NPM: `in-app-purchase`
